### PR TITLE
Use unused save file areas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /rom.nds.skytemple/debugger
 
 
-out.*
+out*
 
 *.nds
 *.sav

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,10 @@
 /rom.nds.skytemple/debugger
 
 
-out.bin
-out.elf
-out.asm
+out.*
 
 *.nds
+*.sav
 *.exps.sm
 *.ssb.sha256
 

--- a/patches/patch.asm
+++ b/patches/patch.asm
@@ -10,6 +10,42 @@
 
     .org IqScalingGroundHook
         bl IqScalingGround
+    
+    ; Save-related stuff
+    .org ClearAdventureLogStructCallsite
+    .area 0x4
+        bl CustomClearAdventureLogStruct
+    .endarea
+
+    .org WriteSaveFileCallsite1
+    .area 0x4
+        bl SaveMoreDataWrapper1
+    .endarea
+
+    .org WriteSaveFileCallsite2
+    .area 0x4
+        bl SaveMoreDataWrapper2
+    .endarea
+
+    .org WriteSaveFileCallsite3
+    .area 0x4
+        bl SaveMoreDataWrapper3
+    .endarea
+
+    .org WriteSaveFileCallsite4
+    .area 0x4
+        bl SaveMoreDataWrapper4
+    .endarea
+    
+    .org LoadSaveFileCallsite1
+    .area 0x4
+        bl LoadMoreDataWrapper1
+    .endarea
+    
+    .org LoadSaveFileCallsite2
+    .area 0x4
+        bl LoadMoreDataWrapper2
+    .endarea
 .close
 
 .open "overlay11.bin", overlay11_start

--- a/src/extern.h
+++ b/src/extern.h
@@ -29,3 +29,11 @@ typedef struct ArchipelagoData {
     unsigned int seed[2];
     ArchipelagoSettings settings;
 } ArchipelagoData;
+
+typedef struct CustomSaveArea {
+    uint32_t checksum;
+    undefined fields[0x10FC];
+} CustomSaveArea;
+ASSERT_SIZE(CustomSaveArea, 0x1100);
+
+extern CustomSaveArea CUSTOM_SAVE_AREA;

--- a/src/save.c
+++ b/src/save.c
@@ -1,0 +1,38 @@
+#include <pmdsky.h>
+#include <cot.h>
+#include "extern.h"
+
+int SaveMoreData(int* file_offset, void* buf, int size, int new_file_offset, bool force_save_flag) {
+  int save_status = WriteSaveFile(file_offset, buf, size);
+  if(save_status == 0 || force_save_flag) {
+    *file_offset = new_file_offset;
+    save_status = WriteSaveFile(file_offset, &CUSTOM_SAVE_AREA, sizeof(CustomSaveArea));
+  }
+  return save_status;
+}
+
+int LoadMoreData(int* file_offset, void* buf, int size, int new_file_offset) {
+  int load_status = ReadSaveFile(file_offset, buf, size);
+  if(load_status == 0) {
+    *file_offset = new_file_offset;
+    load_status = ReadSaveFile(file_offset, &CUSTOM_SAVE_AREA, sizeof(CustomSaveArea));
+  }
+  return load_status;
+}
+
+__attribute((used)) void CustomClearAdventureLogStruct() {
+  ClearAdventureLogStruct();
+  MemZero(&CUSTOM_SAVE_AREA, sizeof(CustomSaveArea));
+}
+
+__attribute((used)) int SaveMoreDataWrapper1(int* file_offset, void* buf, int size, int new_file_offset) { return SaveMoreData(file_offset, buf, size, 0xB7, false); }
+
+__attribute((used)) int SaveMoreDataWrapper2(int* file_offset, void* buf, int size, int new_file_offset) { return SaveMoreData(file_offset, buf, size, 0x17F, true); }
+
+__attribute((used)) int SaveMoreDataWrapper3(int* file_offset, void* buf, int size, int new_file_offset) { return SaveMoreData(file_offset, buf, size, 0x17F, false); }
+
+__attribute((used)) int SaveMoreDataWrapper4(int* file_offset, void* buf, int size, int new_file_offset) { return SaveMoreData(file_offset, buf, size, 0xB7, true); }
+
+__attribute((used)) int LoadMoreDataWrapper1(int* file_offset, void* buf, int size, int new_file_offset) { return LoadMoreData(file_offset, buf, size, 0xB7); }
+
+__attribute((used)) int LoadMoreDataWrapper2(int* file_offset, void* buf, int size, int new_file_offset) { return LoadMoreData(file_offset, buf, size, 0x17F); }

--- a/src/save.c
+++ b/src/save.c
@@ -3,19 +3,19 @@
 #include "extern.h"
 
 int SaveMoreData(int* file_offset, void* buf, int size, int new_file_offset, bool force_save_flag) {
-  int save_status = WriteSaveFile(file_offset, buf, size);
+  int save_status = WriteSaveFile((undefined*)file_offset, buf, size);
   if(save_status == 0 || force_save_flag) {
     *file_offset = new_file_offset;
-    save_status = WriteSaveFile(file_offset, &CUSTOM_SAVE_AREA, sizeof(CustomSaveArea));
+    save_status = WriteSaveFile((undefined*)file_offset, (undefined*)&CUSTOM_SAVE_AREA, sizeof(CustomSaveArea));
   }
   return save_status;
 }
 
 int LoadMoreData(int* file_offset, void* buf, int size, int new_file_offset) {
-  int load_status = ReadSaveFile(file_offset, buf, size);
+  int load_status = ReadSaveFile((undefined*)file_offset, buf, size);
   if(load_status == 0) {
     *file_offset = new_file_offset;
-    load_status = ReadSaveFile(file_offset, &CUSTOM_SAVE_AREA, sizeof(CustomSaveArea));
+    load_status = ReadSaveFile((undefined*)file_offset, (undefined*)&CUSTOM_SAVE_AREA, sizeof(CustomSaveArea));
   }
   return load_status;
 }

--- a/symbols/custom_EU.ld
+++ b/symbols/custom_EU.ld
@@ -2,6 +2,13 @@
 GenerateKecleonItems1Hook = 0x2010B20;
 GenerateKecleonItems2Hook = 0x2010E30;
 IqScalingGroundHook = 0x20119FC;
+WriteSaveFileCallsite1 = 0x02049470;
+WriteSaveFileCallsite2 = 0x02049498;
+WriteSaveFileCallsite3 = 0x020494B0;
+WriteSaveFileCallsite4 = 0x020494D8;
+LoadSaveFileCallsite1 = 0x020496F4;
+LoadSaveFileCallsite2 = 0x02049714;
+ClearAdventureLogStructCallsite = 0x02048774;
 
 /* ! For Overlay11 */
 NameAutofillHook = 0x22E6B94;
@@ -31,6 +38,7 @@ archipelagoAreaStart = 0x23DE000;
 apSlotName = 0x23DE000;
 apSeed = 0x23DE010;
 apSettings = 0x23DE018;
+CUSTOM_SAVE_AREA = 0x23B0000;
 
 /* Undocumented Functions 
    Note: You may to remove some of these definitions if they become defined


### PR DESCRIPTION
Claims unused save areas in the save file, capable of storing 0x1100 bytes within the save file starting at offsets 0xB700 and 0x17F00. When reading/writing a save file, the data is also stored back in Overlay36 starting at 0x23B0000, to be referenced in code via `CUSTOM_SAVE_AREA`. The checksum of `CUSTOM_SAVE_AREA` must not be manually edited, as this updates on a call to `WriteSaveFile`.

Works fine on my end, but should ideally be further tested by others.