### PR TITLE
Adjust CRASS to use a relative return file offset

### DIFF
--- a/src/crass.c
+++ b/src/crass.c
@@ -287,11 +287,14 @@ __attribute((used)) bool GetRecoverCoroutineInfo(struct coroutine_info* coroutin
 */
 __attribute((used)) void CustomInitScriptRoutineFromCoroutineInfo(struct script_routine* routine, undefined4 param_2, struct coroutine_info* coroutine_info, int status) {
   InitScriptRoutineFromCoroutineInfo(routine, param_2, coroutine_info, status);
-  if(CRASS_SETTINGS.coroutine_hijack && CRASS_SETTINGS.return_info.next_opcode_addr != NULL) {
-    if(CRASS_SETTINGS.redirect)
-      MemcpySimple(&(routine->states[0].ssb_info[1]), &(CRASS_SETTINGS.return_info), sizeof(struct ssb_runtime_info)); // Setting up fields to be used by OPCODE_RETURN
-    else
-      routine->states[0].ssb_info[0].next_opcode_addr = CRASS_SETTINGS.return_info.next_opcode_addr; // Next opcode address is the opcode following the skipped OPCODE_SUPERVISION_EXECUTE_ACITNG_SUB
+  if(CRASS_SETTINGS.coroutine_hijack && CRASS_SETTINGS.return_offset != NULL) {
+    uint8_t idx = 0;
+    if(CRASS_SETTINGS.redirect) {
+      MemcpySimple(&(routine->states[0].ssb_info[1]), &(routine->states[0].ssb_info[0]), sizeof(struct ssb_runtime_info)); // Setting up fields to be used by OPCODE_RETURN
+      idx = 1;
+    }
+    // Next opcode address is the opcode following the skipped OPCODE_SUPERVISION_EXECUTE_ACITNG_SUB...
+    routine->states[0].ssb_info[idx].next_opcode_addr = (uint32_t)(routine->states[0].ssb_info[idx].file) + CRASS_SETTINGS.return_offset;
     CRASS_SETTINGS.redirect = false;
     CRASS_SETTINGS.skip_active = false;
     CRASS_SETTINGS.coroutine_hijack = false;
@@ -370,8 +373,8 @@ __attribute((used)) void CustomGetSceneName(char* truncated_scene_name, char* fu
       else if(next_opcode_id == OPCODE_END || next_opcode_id == OPCODE_HOLD)
         CRASS_SETTINGS.end_after_cutscene = true; // Cutscene may need to be sped up, so note it for a later check in TryCutsceneSkipScan
       CRASS_SETTINGS.can_skip = true;
-      // Save the state of the script runtime info to perform a proper return after a skip
-      MemcpySimple(&(CRASS_SETTINGS.return_info), &(GROUND_STATE_PTRS.main_routine->states[0].ssb_info[0]), sizeof(struct ssb_runtime_info));
+      // Save the return offset to perform a proper return after a skip!
+      CRASS_SETTINGS.return_offset = (uint32_t)(next_opcode_addr) - (uint32_t)(GROUND_STATE_PTRS.main_routine->states[0].ssb_info[0].file);
       break;
     case CRASS_SPEEDUP:;
     skip_speedup:;

--- a/src/crass.h
+++ b/src/crass.h
@@ -41,10 +41,8 @@ enum crass_kind {
 };
 
 struct crass_settings {
-  struct ssb_runtime_info
-      return_info; // Used to return control flow back to either the next opcode
-                   // after OPCODE_SUPERVISION_EXECUTE_ACTING_SUB or via
-                   // OPCODE_RETURN in ROUTINE_MAP_TEST.
+  uint32_t return_offset; // The offset in Unionall (relative to
+                          // ssb_runtime_info::file) to return to.
   enum crass_kind
       crass_kind; // To indicate the kind of cutscene skip taken place. Only
                   // really intended to be used in ROUTINE_MAP_TEST, when


### PR DESCRIPTION
Should properly fix the underlying cause behind https://github.com/CrypticMonkey33/ArchipelagoExplorersOfSky/issues/152.

CRASS now uses a relative file return offset as opposed to an absolute address. The issue with using an absolute address is that, on rare occasion, Unionall's address shifts before and after a cutscene skip. By keeping a relative offset, the correct "next opcode" address can be calculated no matter where Unionall resides in memory.