### PR TITLE
Implement credits text preprocessing

### DIFF
--- a/patches/patch.asm
+++ b/patches/patch.asm
@@ -259,6 +259,11 @@
         bl AddItemToBagWithMultiworldCheck
 .close
 
+.open "overlay28.bin", overlay28_start
+    .org CreditsDisplayText
+        bl PreprocessAndAnalyzeCreditsText
+.close
+
 .open "overlay29.bin", overlay29_start
     .org LevelScalingHook
         bl DoLevelScalingWrapper

--- a/src/credits.c
+++ b/src/credits.c
@@ -1,0 +1,10 @@
+#include <pmdsky.h>
+#include <cot.h>
+#include "extern.h"
+
+void PreprocessAndAnalyzeCreditsText(undefined param_1, undefined param_2, undefined param_3, const char* credits_text) {
+  char buffer[0x400];
+  struct preprocessor_flags flags;
+  PreprocessString(buffer, 0x400, credits_text, flags, NULL);
+  AnalyzeTextPreamble(param_1, param_2, param_3, buffer);
+}

--- a/src/extern.h
+++ b/src/extern.h
@@ -166,5 +166,6 @@ void LoadBackgroundDungeon(void* thing, uint32_t* regionInfo, uint32_t num1, uin
 void SetupBackgroundDungeon(void* thing);
 void FreeTopScreenBGDungeon(void* thing);
 void RemoveEmptyItemsInStorage();
+void AnalyzeTextPreamble(undefined param_1, undefined param_2, undefined param_3, char* buffer);
 
 static inline bool IsWithinRange(int x, int min, int max) { return min <= x && x <= max; }

--- a/symbols/custom_EU.ld
+++ b/symbols/custom_EU.ld
@@ -105,6 +105,9 @@ AddShopItemToInventoryHook2 = 0x238B138;
 AddShopItemToInventoryHook3 = 0x238B724;
 AddShopItemToInventoryHook4 = 0x238B784;
 
+/* ! For Overlay28 */
+CreditsDisplayText = 0x238B82C;
+
 /* ! For Overlay29 */
 LevelScalingHook = 0x22E80B0; /* In LoadMappaFileAttributes */
 IqScalingDungeonHook = 0x22FAB68;
@@ -163,6 +166,7 @@ CloseMode5TopScreenDungeon = 0x22E9058;
 TopScreenModeSetDungeonMode = 0x22E9658;
 FreeTopScreenBGDungeon = 0x22C2BD0;
 RemoveEmptyItemsInStorage = 0x2010124;
+AnalyzeTextPreamble = 0x20264F8;
 
 /* Ap Tracker Top Screen Stuff */
 UnkTopScreenFun1 = 0x22EC7EC;


### PR DESCRIPTION
The text displayed in the credits will now undergo preprocessing via `PreprocessString`, i.e., lowercase text tags will no longer be ignored when printing credits text.

(Requested by @HappyLappy1)